### PR TITLE
Add electron range calculation and update workflows

### DIFF
--- a/.github/workflows/linux-reusable.yml
+++ b/.github/workflows/linux-reusable.yml
@@ -31,6 +31,7 @@ jobs:
           pip show -f pyamtrack
           python -c "import pyamtrack; print(pyamtrack.__doc__); print(dir(pyamtrack)); print(pyamtrack.calculate_velocity(2));"
           python -c "import pyamtrack; print(pyamtrack.beta_from_energy(150));"
+          python -c "import pyamtrack; print(pyamtrack.electron_range(150));"
 
       - name: Upload Linux Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/macos-reusable.yml
+++ b/.github/workflows/macos-reusable.yml
@@ -1,4 +1,7 @@
 name: macOS Build & Test
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   workflow_call:
@@ -35,6 +38,7 @@ jobs:
           pip show -f pyamtrack
           python -c "import pyamtrack; print(pyamtrack.__doc__); print(dir(pyamtrack)); print(pyamtrack.calculate_velocity(2));"
           python -c "import pyamtrack; print(pyamtrack.beta_from_energy(150));"
+          python -c "import pyamtrack; print(pyamtrack.electron_range(150));"
 
       - name: Upload macOS Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -47,7 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        # os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/windows-reusable.yml
+++ b/.github/workflows/windows-reusable.yml
@@ -92,7 +92,7 @@ jobs:
           pip show -f pyamtrack
           python -c "import pyamtrack; print(pyamtrack.__doc__); print(dir(pyamtrack)); print(pyamtrack.calculate_velocity(2));"
           python -c "import pyamtrack; print(pyamtrack.beta_from_energy(150));"
-
+          python -c "import pyamtrack; print(pyamtrack.electron_range(150));"
 
       - name: Upload Windows Artifact
         uses: actions/upload-artifact@v4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,11 +7,18 @@ namespace py = pybind11;
 
 extern "C" {
     #include "AT_PhysicsRoutines.h"  // Include libamtrack header
+    #include "AT_ElectronRange.h"  // Include libamtrack header
+
 }
 
 // Wrapper function for AT_beta_from_E_single (from libamtrack)
 double beta_from_energy(double E_MeV_u) {
     return AT_beta_from_E_single(E_MeV_u);
+}
+
+double electron_range(double E_MeV_u) {
+    const double range = AT_max_electron_range_m(E_MeV_u, 1, 7);
+    return range;
 }
 
 // Additional custom function not using libamtrack
@@ -28,6 +35,9 @@ PYBIND11_MODULE(_core, m) {
 
     // Expose the calculate_velocity function
     m.def("calculate_velocity", &calculate_velocity, "Calculate velocity from beta (m/s)");
+
+    // Expose the electron_range function
+    m.def("electron_range", &electron_range, "Calculate electron range (m)");
 
 #ifdef VERSION_INFO
     m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/src/pyamtrack/__init__.py
+++ b/src/pyamtrack/__init__.py
@@ -27,6 +27,6 @@ if sys.platform == "win32":
         except OSError as e:
             print(f"Warning: failed to load {dll_name} from {dll_path}: {e}")
 
-from ._core import __doc__, __version__, calculate_velocity, beta_from_energy
+from ._core import __doc__, __version__, calculate_velocity, beta_from_energy, electron_range
 
-__all__ = ["__doc__", "__version__", "calculate_velocity", "beta_from_energy"]
+__all__ = ["__doc__", "__version__", "calculate_velocity", "beta_from_energy", "electron_range"]


### PR DESCRIPTION
This pull request includes several changes to the build and test workflows, as well as the addition of a new function to the codebase. The most important changes include adding permissions to the macOS workflow, updating the test scripts, and exposing a new function for calculating electron range.

### Workflow updates:

* [`.github/workflows/macos-reusable.yml`](diffhunk://#diff-a0e3f173ffb1cc333c2000e3b324239b23c08135796c706fa8b6552b3a99bd93R2-R4): Added read and write permissions for contents and pull-requests.
* `.github/workflows/linux-reusable.yml`, `.github/workflows/macos-reusable.yml`, `.github/workflows/windows-reusable.yml`: Updated the test scripts to include a call to `pyamtrack.electron_range(150)`. [[1]](diffhunk://#diff-ccb175809fadb7984170e6a9c1617195b70de4ae18c8ac07270d614903d7f418R34) [[2]](diffhunk://#diff-a0e3f173ffb1cc333c2000e3b324239b23c08135796c706fa8b6552b3a99bd93R41) [[3]](diffhunk://#diff-68ead3221589a8cc1381973f14a6889f81355ebd4685eacb1a9b16a4edbb43b6L95-R95)
* [`.github/workflows/wheels.yml`](diffhunk://#diff-75627befeafda60a526c116b32f6fdef9bf57bcf456f840d7592c1d6f13facb4L50): Removed commented-out lines related to additional operating systems in the matrix configuration.

### Codebase updates:

* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R10-R23): Added a new function `electron_range` that calculates electron range and exposed it using `PYBIND11_MODULE`. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R10-R23) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R39-R41)
* [`src/pyamtrack/__init__.py`](diffhunk://#diff-871b554e452e6e38ae9213f6a611e6ffea5ec2a1e95af57baab505f1d0989733L30-R32): Imported and included the new `electron_range` function in the `__all__` list.