### PR TITLE
Add Windows support to wheels build matrix

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,8 @@ jobs:
 
     - uses: pypa/cibuildwheel@v2.22
       env:
-        CIBW_ENVIRONMENT: VCPKG_INSTALLED_DIR="${{ github.workspace }}/vcpkg_installed"
+        CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR=${{ github.workspace }}/vcpkg_installed
+        CIBW_TEST_COMMAND: python -c "import pyamtrack; print(pyamtrack.electron_range(100));"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,11 +55,9 @@ jobs:
       with:
         submodules: true
 
-    - uses: astral-sh/setup-uv@v4
-
     - uses: pypa/cibuildwheel@v2.22
       env:
-        CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR=""D:/a/pyamtrack/pyamtrack/vcpkg_installed/x64-windows/include""
+        CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR="D:/a/pyamtrack/pyamtrack/vcpkg_installed/"
         CIBW_TEST_COMMAND: python -c "import pyamtrack; print(pyamtrack.electron_range(100));"
 
     - name: Verify clean directory

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -55,7 +55,7 @@ jobs:
       with:
         submodules: true
 
-    - uses: pypa/cibuildwheel@v2.22
+    - uses: pypa/cibuildwheel@v2.23
       env:
         CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR="D:/a/pyamtrack/pyamtrack/vcpkg_installed/"
         CIBW_TEST_COMMAND: python -c "import pyamtrack; print(pyamtrack.electron_range(100));"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -58,6 +58,8 @@ jobs:
     - uses: astral-sh/setup-uv@v4
 
     - uses: pypa/cibuildwheel@v2.22
+      env:
+        CIBW_ENVIRONMENT: VCPKG_INSTALLED_DIR="${{ github.workspace }}/vcpkg_installed"
 
     - name: Verify clean directory
       run: git diff --exit-code

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
 
     - uses: pypa/cibuildwheel@v2.22
       env:
-        CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR=${{ github.workspace }}/vcpkg_installed
+        CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR=${{ github.workspace }}\vcpkg_installed
         CIBW_TEST_COMMAND: python -c "import pyamtrack; print(pyamtrack.electron_range(100));"
 
     - name: Verify clean directory

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -59,7 +59,7 @@ jobs:
 
     - uses: pypa/cibuildwheel@v2.22
       env:
-        CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR=${{ github.workspace }}\vcpkg_installed
+        CIBW_ENVIRONMENT_WINDOWS: VCPKG_INSTALLED_DIR=""D:/a/pyamtrack/pyamtrack/vcpkg_installed/x64-windows/include""
         CIBW_TEST_COMMAND: python -c "import pyamtrack; print(pyamtrack.electron_range(100));"
 
     - name: Verify clean directory

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ minimum-version = "build-system.requires"
 
 [tool.cibuildwheel]
 archs = ["auto64"]
+skip= ["cp36-*", "cp37-*", "cp38-*", "pp*"]
 
 [tool.cibuildwheel.linux]
 before-all = "./scripts/build_gsl.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ archs = ["auto64"]
 [tool.cibuildwheel.windows]
 before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
-environment = { VCPKG_INSTALLED_DIR = "D:\\a\\pyamtrack\\pyamtrack\\vcpkg_installed" }
+environment = { VCPKG_INSTALLED_DIR = "D:/a/pyamtrack/pyamtrack/vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ archs = ["auto64"]
 [tool.cibuildwheel.windows]
 before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
-environment = { VCPKG_INSTALLED_DIR = "{project}/vcpkg_installed" }
+environment = { VCPKG_INSTALLED_DIR = "D:\a\pyamtrack\pyamtrack\vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,6 @@ build = "cp311-manylinux* cp312-manylinux* cp313-manylinux*"
 archs = ["auto64"]
 
 [tool.cibuildwheel.windows]
-before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl_windows.ps1"
+before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
 environment = { VCPKG_INSTALLED_DIR = "C:/vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ skip= ["cp36-*", "cp37-*", "cp38-*", "pp*"]
 
 [tool.cibuildwheel.linux]
 before-all = "./scripts/build_gsl.sh"
-build = "cp311-manylinux* cp312-manylinux* cp313-manylinux*"
 
 [tool.cibuildwheel.windows]
 before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
-build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ archs = ["auto64"]
 [tool.cibuildwheel.windows]
 before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
-environment = { VCPKG_INSTALLED_DIR = "D:\a\pyamtrack\pyamtrack\vcpkg_installed" }
+environment = { VCPKG_INSTALLED_DIR = "D:\\a\\pyamtrack\\pyamtrack\\vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,13 @@ license = { file = "LICENSE" }
 wheel.expand-macos-universal-tags = true
 minimum-version = "build-system.requires"
 
+[tool.cibuildwheel]
+archs = ["auto64"]
+
 [tool.cibuildwheel.linux]
 before-all = "./scripts/build_gsl.sh"
 build = "cp311-manylinux* cp312-manylinux* cp313-manylinux*"
-archs = ["auto64"]
 
 [tool.cibuildwheel.windows]
 before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
-#environment = { VCPKG_INSTALLED_DIR = "D:/a/pyamtrack/pyamtrack/vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,6 @@ build = "cp311-manylinux* cp312-manylinux* cp313-manylinux*"
 archs = ["auto64"]
 
 [tool.cibuildwheel.windows]
-before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
+before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl_windows.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
-environment = { VCPKG_INSTALLED_DIR = "C:\\vcpkg_installed" }
+environment = { VCPKG_INSTALLED_DIR = "C:/vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ archs = ["auto64"]
 [tool.cibuildwheel.windows]
 before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
-environment = { VCPKG_INSTALLED_DIR = "C:/vcpkg_installed" }
+environment = { VCPKG_INSTALLED_DIR = "{project}/vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,4 @@ archs = ["auto64"]
 [tool.cibuildwheel.windows]
 before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
 build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
-environment = { VCPKG_INSTALLED_DIR = "D:/a/pyamtrack/pyamtrack/vcpkg_installed" }
+#environment = { VCPKG_INSTALLED_DIR = "D:/a/pyamtrack/pyamtrack/vcpkg_installed" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,8 @@ minimum-version = "build-system.requires"
 before-all = "./scripts/build_gsl.sh"
 build = "cp311-manylinux* cp312-manylinux* cp313-manylinux*"
 archs = ["auto64"]
+
+[tool.cibuildwheel.windows]
+before-all = "powershell.exe -ExecutionPolicy Bypass -File scripts/build_gsl.ps1"
+build = "cp311-win_amd64 cp312-win_amd64 cp313-win_amd64"
+environment = { VCPKG_INSTALLED_DIR = "C:\\vcpkg_installed" }

--- a/scripts/build_gsl.ps1
+++ b/scripts/build_gsl.ps1
@@ -14,7 +14,7 @@ if (-Not (Test-Path "$workspace\vcpkg")) {
 
 # Install dependencies using vcpkg
 $env:VCPKG_DEFAULT_BINARY_CACHE = $vcpkgCache
-$env:VCPKG_INSTALLED_DIR = $vcpkgInstalled
+$env:VCPKG_INSTALLED_DIR = "$workspace/vcpkg_installed"
 & "$workspace\vcpkg\vcpkg.exe" install
 
 Write-Output "VCPKG setup completed."

--- a/scripts/build_gsl.ps1
+++ b/scripts/build_gsl.ps1
@@ -1,0 +1,20 @@
+# Set up directories
+$workspace = "$PWD"
+$vcpkgCache = "$workspace\vcpkg_cache"
+$vcpkgInstalled = "$workspace\vcpkg_installed"
+
+if (-Not (Test-Path $vcpkgCache)) { New-Item -ItemType Directory -Path $vcpkgCache }
+if (-Not (Test-Path $vcpkgInstalled)) { New-Item -ItemType Directory -Path $vcpkgInstalled }
+
+# Restore or install vcpkg
+if (-Not (Test-Path "$workspace\vcpkg")) {
+    git clone --depth 1 https://github.com/microsoft/vcpkg "$workspace\vcpkg"
+    & "$workspace\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
+}
+
+# Install dependencies using vcpkg
+$env:VCPKG_DEFAULT_BINARY_CACHE = $vcpkgCache
+$env:VCPKG_INSTALLED_DIR = $vcpkgInstalled
+& "$workspace\vcpkg\vcpkg.exe" install
+
+Write-Output "VCPKG setup completed."


### PR DESCRIPTION
This pull request includes several changes to the build and workflow configuration to support Windows builds and improve the build process. The most important changes include adding Windows to the build matrix, updating the `cibuildwheel` version, and configuring the build environment for Windows.

### Build and Workflow Configuration:

* [`.github/workflows/wheels.yml`](diffhunk://#diff-75627befeafda60a526c116b32f6fdef9bf57bcf456f840d7592c1d6f13facb4L51-R61): Added `windows-latest` to the OS matrix and updated `cibuildwheel` to version 2.23. Configured the Windows build environment and test command.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R19-R29): Added `cibuildwheel` configuration for Windows, specifying architectures and build commands.

### Script Additions:

* [`scripts/build_gsl.ps1`](diffhunk://#diff-facff651ef80818bbf9929bd6b10057d6792b338aaeb3c2f5f86ecd403020642R1-R20): Added a PowerShell script to set up directories, restore or install `vcpkg`, and install dependencies using `vcpkg` for Windows builds.