### PR TITLE
Faster builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,3 @@ jobs:
     uses: ./.github/workflows/macos-reusable.yml
     with:
       linux_status: ${{ needs.build_and_test_linux.result }}
-
-  build_and_test_windows:
-    name: Windows Build & Test
-    needs: build_and_test_linux
-    if: ${{ needs.build_and_test_linux.result == 'success' }}
-    uses: ./.github/workflows/windows-reusable.yml
-    with:
-      linux_status: ${{ needs.build_and_test_linux.result }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -4,17 +4,14 @@ permissions:
   pull-requests: write
 
 on:
-  workflow_call:
-    inputs:
-      linux_status:
-        description: 'Status of the Linux Build job'
-        required: true
-        type: string
+    workflow_dispatch:
+    push:
+      branches:
+       - master
 
 jobs:
   build_and_test_windows:
     runs-on: windows-latest
-    if: ${{ inputs.linux_status == 'success' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to streamline and simplify the CI/CD process. The most significant changes involve removing the Windows build and test job from the main workflow and updating the Windows workflow file to be triggered by specific events.

Changes to CI/CD workflows:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L31-L38): Removed the `build_and_test_windows` job, which previously depended on the Linux build job.
* [`.github/workflows/windows.yml`](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL7-L17): Renamed from `windows-reusable.yml` and updated to be triggered by `workflow_dispatch` and `push` events instead of being called by another workflow. Removed the dependency on the Linux build job status.