### PR TITLE
Add Python setup action to CI workflows for Linux, macOS, and Windows

### DIFF
--- a/.github/workflows/linux-reusable.yml
+++ b/.github/workflows/linux-reusable.yml
@@ -20,6 +20,10 @@ jobs:
       - name: Install system packages
         run: sudo apt-get install -y --no-install-recommends libgsl-dev python3-pip python3-venv
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+        
       - name: Install Python build tools
         run: pip install --upgrade build
 

--- a/.github/workflows/macos-reusable.yml
+++ b/.github/workflows/macos-reusable.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Install system packages
         run: brew install gsl
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Install Python dependencies
         run: pip install --upgrade build
   

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -69,6 +69,10 @@ jobs:
           VCPKG_INSTALLED_DIR: ${{ github.workspace }}/vcpkg_installed
         run: .\vcpkg\vcpkg.exe install
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
       - name: Install Python dependencies
         run: pip install --upgrade build
   


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for Linux, macOS, and Windows environments. The main change is the addition of a step to set up Python using the `actions/setup-python` action.

Updates to GitHub Actions workflows:

* [`.github/workflows/linux-reusable.yml`](diffhunk://#diff-ccb175809fadb7984170e6a9c1617195b70de4ae18c8ac07270d614903d7f418R23-R26): Added a step to set up Python using `actions/setup-python@v5` with `python-version: "3.x"`.
* [`.github/workflows/macos-reusable.yml`](diffhunk://#diff-a0e3f173ffb1cc333c2000e3b324239b23c08135796c706fa8b6552b3a99bd93R27-R30): Added a step to set up Python using `actions/setup-python@v5` with `python-version: "3.x"`.
* [`.github/workflows/windows.yml`](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cR72-R75): Added a step to set up Python using `actions/setup-python@v5` with `python-version: "3.x"`.