### PR TITLE
68 use wrap function in electron range

### DIFF
--- a/src/converters/beta_from_energy.h
+++ b/src/converters/beta_from_energy.h
@@ -3,7 +3,8 @@
 
 #include <pybind11/pybind11.h>
 
+namespace py = pybind11;
 
-pybind11::object PYBIND11_EXPORT beta_from_energy(pybind11::object input);
+py::object PYBIND11_EXPORT beta_from_energy(py::object input);
 
 #endif // BETA_FROM_ENERGY_H

--- a/src/converters/energy_from_beta.h
+++ b/src/converters/energy_from_beta.h
@@ -5,8 +5,6 @@
 
 namespace py = pybind11;
 
-
-
 py::object PYBIND11_EXPORT energy_from_beta(py::object input);
 
 #endif // ENERGY_FROM_BETA_H

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -1,7 +1,5 @@
+#include "../wrapper_template.h"
 #include "electron_range.h"
-#include <pybind11/numpy.h>
-#include <pybind11/stl.h>
-#include <stdexcept>
 
 extern "C" {
     #include "AT_ElectronRange.h"
@@ -16,29 +14,5 @@ double electron_range_single(double E_MeV_u) {
 
 // Main function to handle different input types
 py::object electron_range(py::object input) {
-    if (py::isinstance<py::float_>(input) || py::isinstance<py::int_>(input)) {
-        double energy = input.cast<double>();
-        return py::float_(electron_range_single(energy));
-    } else if (py::isinstance<py::array_t<double>>(input)) {
-        auto energies = input.cast<py::array_t<double>>();
-        auto r = energies.unchecked<1>();
-        py::array_t<double> result(energies.size());
-        auto res = result.mutable_unchecked<1>();
-
-        for (std::ptrdiff_t i = 0; i < r.size(); i++) {
-            res(i) = electron_range_single(r(i));
-        }
-
-        return result;
-    } else if (py::isinstance<py::list>(input)) {
-        py::list energies = input.cast<py::list>();
-        py::list result;
-        for (auto energy : energies) {
-            double e = py::cast<double>(energy);
-            result.append(electron_range_single(e));
-        }
-        return result;
-    } else {
-        throw std::invalid_argument("Input must be a float, int, NumPy array, or a Python list of numbers.");
-    }
+    return wrap_function(electron_range_single, input);
 }

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -5,8 +5,6 @@ extern "C" {
     #include "AT_ElectronRange.h"
 }
 
-namespace py = pybind11;
-
 // Helper function for single value calculation
 double electron_range_single(double E_MeV_u) {
     return AT_max_electron_range_m(E_MeV_u, 1, 7);

--- a/src/stopping/electron_range.h
+++ b/src/stopping/electron_range.h
@@ -3,6 +3,8 @@
 
 #include <pybind11/pybind11.h>
 
-pybind11::object PYBIND11_EXPORT electron_range(pybind11::object input);
+namespace py = pybind11;
+
+py::object PYBIND11_EXPORT electron_range(py::object input);
 
 #endif // ELECTRON_RANGE_H


### PR DESCRIPTION
This pull request includes several changes to improve the consistency and maintainability of the codebase, specifically in the handling of the `pybind11` namespace and the simplification of the `electron_range` function.

Improvements to namespace handling:

* [`src/converters/beta_from_energy.h`](diffhunk://#diff-fb3fc88ec5ed9dda3e83de9474304c67b0b33bc34e723fa6227dd47a01c05085R6-R8): Replaced `pybind11::object` with `py::object` and added a namespace alias for `pybind11`.
* [`src/converters/energy_from_beta.h`](diffhunk://#diff-26946eeda1a63f417753d38dda35b9315d5bcb86f66c4ea97ea0979837060982L8-L9): Removed unnecessary blank lines and added a namespace alias for `pybind11`.
* [`src/stopping/electron_range.h`](diffhunk://#diff-6412be15b3cde7648f0f5764aaced441e619892663e5c58991ef7c8a9a151c3dL6-R8): Replaced `pybind11::object` with `py::object` and added a namespace alias for `pybind11`.

Code simplification:

* [`src/stopping/electron_range.cpp`](diffhunk://#diff-a61ac4496e9a22ff3c660b80443d3425ecad6b983ef5f77ae950fdf5bbe002daR1-R15): Simplified the `electron_range` function by using the `wrap_function` helper to handle different input types, removing the explicit type checks and conversions.