### PR TITLE
Add materials module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ FetchContent_MakeAvailable(libamtrack)
 target_link_libraries(amtrack PRIVATE GSL::gsl GSL::gslcblas)
 
 ###############################################################################
-# Build the Python module (_core), converters library, and stopping library
+# Build the Python module (_core) and other targets
 ###############################################################################
 # Add dynamic lookup for macOS to resolve Python symbols at runtime.
 if(APPLE)
@@ -109,7 +109,7 @@ endif()
 python_add_library(_core MODULE src/main.cpp WITH_SOABI)
 
 # Define a list of targets to link against the required libraries.
-set(PYAMTRACK_TARGETS converters stopping)
+set(PYAMTRACK_TARGETS converters stopping materials)
 
 foreach(TARGET ${PYAMTRACK_TARGETS})
   # Create a library for each target.

--- a/src/materials/materials.cpp
+++ b/src/materials/materials.cpp
@@ -11,6 +11,17 @@ Material::Material(long id)
     phase = AT_phase_from_material_no(id);
 }
 
+Material::Material(const std::string& name) {
+    long id = AT_material_number_from_name(name.c_str());
+    if (id < 1) {
+        throw std::invalid_argument("Material not found: " + name);
+    }
+    AT_get_material_data(id, &density_g_cm3, &I_eV, &alpha_g_cm2_MeV, &p_MeV, &m_g_cm2, &average_A, &average_Z);
+    this->id = id;
+    phase = AT_phase_from_material_no(id);
+    this->name = name;
+}
+
 std::vector<long> get_ids() {
     const AT_table_of_material_data_struct& data = AT_Material_Data;
     return std::vector<long>(std::begin(data.material_no) + 1, std::begin(data.material_no) + data.n);

--- a/src/materials/materials.cpp
+++ b/src/materials/materials.cpp
@@ -4,6 +4,10 @@
 
 Material::Material(long id)
     : id(id) {
+    auto material_index = AT_material_index_from_material_number(id);
+    if (material_index < 0) {
+        throw std::invalid_argument("Material not found: " + std::to_string(id));
+    }
     AT_get_material_data(id, &density_g_cm3, &I_eV, &alpha_g_cm2_MeV, &p_MeV, &m_g_cm2, &average_A, &average_Z);
     char material_name[MATERIAL_NAME_LENGTH];
     AT_material_name_from_number(id, material_name);
@@ -12,7 +16,7 @@ Material::Material(long id)
 }
 
 Material::Material(const std::string& name) {
-    long id = AT_material_number_from_name(name.c_str());
+    auto id = AT_material_number_from_name(name.c_str());
     if (id < 1) {
         throw std::invalid_argument("Material not found: " + name);
     }

--- a/src/materials/materials.cpp
+++ b/src/materials/materials.cpp
@@ -1,4 +1,6 @@
 #include "materials.h"
+#include <algorithm>
+#include <cctype>
 
 Material::Material(long id)
     : id(id) {
@@ -7,4 +9,27 @@ Material::Material(long id)
     AT_material_name_from_number(id, material_name);
     name = std::string(material_name);
     phase = AT_phase_from_material_no(id);
+}
+
+std::vector<long> get_ids() {
+    const AT_table_of_material_data_struct& data = AT_Material_Data;
+    return std::vector<long>(std::begin(data.material_no) + 1, std::begin(data.material_no) + data.n);
+}
+
+std::vector<std::string> get_long_names() {
+    const AT_table_of_material_data_struct& data = AT_Material_Data;
+    return std::vector<std::string>(std::begin(data.material_name) + 1, std::begin(data.material_name) + data.n);
+}
+
+std::vector<std::string> get_names() {
+    auto names = get_long_names();
+    // Replace all spaces with underscores
+    for (auto& name : names) {
+        std::replace(name.begin(), name.end(), ' ', '_');
+    }
+    // Remove all non-alphanumeric characters
+    for (auto& name : names) {
+        name.erase(std::remove_if(name.begin(), name.end(), [](char c) { return !std::isalnum(c) && c != '_'; }), name.end());
+    }
+    return names;
 }

--- a/src/materials/materials.cpp
+++ b/src/materials/materials.cpp
@@ -1,10 +1,10 @@
 #include "materials.h"
 
-Material::Material(long material_no)
-    : material_no(material_no) {
-    AT_get_material_data(material_no, &density_g_cm3, &I_eV, &alpha_g_cm2_MeV, &p_MeV, &m_g_cm2, &average_A, &average_Z);
-    char name[MATERIAL_NAME_LENGTH];
-    AT_material_name_from_number(material_no, name);
-    material_name = std::string(name);
-    phase = AT_phase_from_material_no(material_no);
+Material::Material(long id)
+    : id(id) {
+    AT_get_material_data(id, &density_g_cm3, &I_eV, &alpha_g_cm2_MeV, &p_MeV, &m_g_cm2, &average_A, &average_Z);
+    char material_name[MATERIAL_NAME_LENGTH];
+    AT_material_name_from_number(id, material_name);
+    name = std::string(material_name);
+    phase = AT_phase_from_material_no(id);
 }

--- a/src/materials/materials.cpp
+++ b/src/materials/materials.cpp
@@ -1,0 +1,10 @@
+#include "materials.h"
+
+Material::Material(long material_no)
+    : material_no(material_no) {
+    AT_get_material_data(material_no, &density_g_cm3, &I_eV, &alpha_g_cm2_MeV, &p_MeV, &m_g_cm2, &average_A, &average_Z);
+    char name[MATERIAL_NAME_LENGTH];
+    AT_material_name_from_number(material_no, name);
+    material_name = std::string(name);
+    phase = AT_phase_from_material_no(material_no);
+}

--- a/src/materials/materials.cpp
+++ b/src/materials/materials.cpp
@@ -21,15 +21,21 @@ std::vector<std::string> get_long_names() {
     return std::vector<std::string>(std::begin(data.material_name) + 1, std::begin(data.material_name) + data.n);
 }
 
+std::string to_name( const std::string& name) {
+    std::string result = name;
+    // Replace all spaces with underscores
+    std::replace(result.begin(), result.end(), ' ', '_');
+    // Remove all non-alphanumeric characters
+    result.erase(std::remove_if(result.begin(), result.end(), [](char c) { return !std::isalnum(c) && c != '_'; }), result.end());
+    // Convert to lowercase
+    std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return std::tolower(c); });
+    return result;
+}
+
 std::vector<std::string> get_names() {
     auto names = get_long_names();
-    // Replace all spaces with underscores
     for (auto& name : names) {
-        std::replace(name.begin(), name.end(), ' ', '_');
-    }
-    // Remove all non-alphanumeric characters
-    for (auto& name : names) {
-        name.erase(std::remove_if(name.begin(), name.end(), [](char c) { return !std::isalnum(c) && c != '_'; }), name.end());
+        name = to_name(name);
     }
     return names;
 }

--- a/src/materials/materials.h
+++ b/src/materials/materials.h
@@ -15,7 +15,7 @@ namespace py = pybind11;
 
 class Material {
     public:
-        long material_no;
+        long id;
         double density_g_cm3;
         double I_eV;
         double alpha_g_cm2_MeV;
@@ -23,10 +23,10 @@ class Material {
         double m_g_cm2;
         double average_A;
         double average_Z;
-        std::string material_name;
+        std::string name;
         long phase;
     
-        Material(long material_no);
+        Material(long id);
     };
     
 

--- a/src/materials/materials.h
+++ b/src/materials/materials.h
@@ -26,14 +26,7 @@ class Material {
         std::string material_name;
         long phase;
     
-        Material(long material_no)
-            : material_no(material_no) {
-            AT_get_material_data(material_no, &density_g_cm3, &I_eV, &alpha_g_cm2_MeV, &p_MeV, &m_g_cm2, &average_A, &average_Z);
-            char name[MATERIAL_NAME_LENGTH];
-            AT_material_name_from_number(material_no, name);
-            material_name = std::string(name);
-            phase = AT_phase_from_material_no(material_no);
-        }
+        Material(long material_no);
     };
     
 

--- a/src/materials/materials.h
+++ b/src/materials/materials.h
@@ -1,0 +1,40 @@
+#ifndef MATERIALS_H
+#define MATERIALS_H
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <string>
+#include <vector>
+
+extern "C" {
+    #include "AT_DataMaterial.h"
+}
+
+namespace py = pybind11;
+
+
+class Material {
+    public:
+        long material_no;
+        double density_g_cm3;
+        double I_eV;
+        double alpha_g_cm2_MeV;
+        double p_MeV;
+        double m_g_cm2;
+        double average_A;
+        double average_Z;
+        std::string material_name;
+        long phase;
+    
+        Material(long material_no)
+            : material_no(material_no) {
+            AT_get_material_data(material_no, &density_g_cm3, &I_eV, &alpha_g_cm2_MeV, &p_MeV, &m_g_cm2, &average_A, &average_Z);
+            char name[MATERIAL_NAME_LENGTH];
+            AT_material_name_from_number(material_no, name);
+            material_name = std::string(name);
+            phase = AT_phase_from_material_no(material_no);
+        }
+    };
+    
+
+#endif // MATERIALS_H

--- a/src/materials/materials.h
+++ b/src/materials/materials.h
@@ -12,26 +12,105 @@ extern "C" {
 
 namespace py = pybind11;
 
+/**
+ * @brief Retrieves the list of material IDs.
+ *
+ * Example:
+ * >>> get_ids()
+ * [1, 2, 3, ..., 24]
+ *
+ * @return std::vector<long> A list of material IDs.
+ */
 std::vector<long> get_ids();
+
+/**
+ * @brief Retrieves the sanitized names of all materials.
+ *
+ * The sanitized names replace spaces with underscores and remove non-alphanumeric characters.
+ *
+ * Example:
+ * >>> get_names()
+ * ['water_liquid', 'aluminum_oxide', 'aluminum', ..., 'lead']
+ *
+ * @return std::vector<std::string> A list of sanitized material names.
+ */
 std::vector<std::string> get_names();
+
+/**
+ * @brief Retrieves the full names of all materials.
+ *
+ * Example:
+ * >>> get_long_names()
+ * ['Water, Liquid', 'Aluminum Oxide', 'Aluminum', ..., 'Lead']
+ *
+ * @return std::vector<std::string> A list of full material names.
+ */
 std::vector<std::string> get_long_names();
 
+/**
+ * @class Material
+ * @brief Represents a material with various physical properties.
+ *
+ * Example:
+ * >>> material = Material(1)
+ * >>> material.id
+ * 1
+ * >>> material.name
+ * 'Water, Liquid'
+ *
+ * Attributes:
+ * - id (int): The unique identifier for the material.
+ * - density_g_cm3 (float): The density of the material in g/cm³.
+ * - I_eV (float): The mean ionization potential in eV.
+ * - alpha_g_cm2_MeV (float): Fit parameter for power-law representation of stopping power.
+ * - p_MeV (float): Fit parameter for power-law representation of stopping power.
+ * - m_g_cm2 (float): Fit parameter for linear representation of fluence changes.
+ * - average_A (float): The average mass number of the material.
+ * - average_Z (float): The average atomic number of the material.
+ * - name (str): The name of the material.
+ * - phase (int): The phase of the material (e.g., condensed or gaseous).
+ */
 class Material {
     public:
-        long id;
-        double density_g_cm3;
-        double I_eV;
-        double alpha_g_cm2_MeV;
-        double p_MeV;
-        double m_g_cm2;
-        double average_A;
-        double average_Z;
-        std::string name;
-        long phase;
-    
+        long id; /**< The unique identifier for the material. */
+        double density_g_cm3; /**< The density of the material in g/cm³. */
+        double I_eV; /**< The mean ionization potential in eV. */
+        double alpha_g_cm2_MeV; /**< Fit parameter for power-law representation of stopping power. */
+        double p_MeV; /**< Fit parameter for power-law representation of stopping power. */
+        double m_g_cm2; /**< Fit parameter for linear representation of fluence changes. */
+        double average_A; /**< The average mass number of the material. */
+        double average_Z; /**< The average atomic number of the material. */
+        std::string name; /**< The name of the material. */
+        long phase; /**< The phase of the material (e.g., condensed or gaseous). */
+
+        /**
+         * @brief Initializes a Material object.
+         *
+         * Example:
+         * >>> material = Material(1)
+         * >>> material.id
+         * 1
+         * >>> material.name
+         * 'Water, Liquid'
+         *
+         * @param id_or_name The unique identifier or name of the material.
+         */
         Material(long id);
+
+        /**
+         * @brief Initializes a Material object using its name.
+         *
+         * Example:
+         * >>> material = Material("Water, Liquid")
+         * >>> material.id
+         * 1
+         * >>> material.name
+         * 'Water, Liquid'
+         *
+         * @param name The name of the material.
+         * @throws std::invalid_argument if the material name is not found.
+         */
         Material(const std::string &name);
-    };
-    
+};
 
 #endif // MATERIALS_H

--- a/src/materials/materials.h
+++ b/src/materials/materials.h
@@ -12,6 +12,9 @@ extern "C" {
 
 namespace py = pybind11;
 
+std::vector<long> get_ids();
+std::vector<std::string> get_names();
+std::vector<std::string> get_long_names();
 
 class Material {
     public:

--- a/src/materials/materials.h
+++ b/src/materials/materials.h
@@ -30,6 +30,7 @@ class Material {
         long phase;
     
         Material(long id);
+        Material(const std::string &name);
     };
     
 

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -20,4 +20,10 @@ PYBIND11_MODULE(materials, m) {
         .def_readonly("material_name", &Material::material_name)
         .def_readonly("phase", &Material::phase);
 
+    m.def("get_material_name", [](long material_no) {
+        char name[MATERIAL_NAME_LENGTH];
+        AT_material_name_from_number(material_no, name);
+        return std::string(name);
+    });
+
 }

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -5,11 +5,11 @@
 namespace py = pybind11;
 
 PYBIND11_MODULE(materials, m) {
-    m.doc() = "Materials";
+    m.doc() = "Functions and data structures for accessing and manipulating material properties.";
 
     py::class_<Material>(m, "Material")
         .def(py::init<long>())
-        .def_readonly("material_no", &Material::material_no)
+        .def_readonly("id", &Material::id)
         .def_readonly("density_g_cm3", &Material::density_g_cm3)
         .def_readonly("I_eV", &Material::I_eV)
         .def_readonly("alpha_g_cm2_MeV", &Material::alpha_g_cm2_MeV)
@@ -17,13 +17,7 @@ PYBIND11_MODULE(materials, m) {
         .def_readonly("m_g_cm2", &Material::m_g_cm2)
         .def_readonly("average_A", &Material::average_A)
         .def_readonly("average_Z", &Material::average_Z)
-        .def_readonly("material_name", &Material::material_name)
+        .def_readonly("name", &Material::name)
         .def_readonly("phase", &Material::phase);
-
-    m.def("get_material_name", [](long material_no) {
-        char name[MATERIAL_NAME_LENGTH];
-        AT_material_name_from_number(material_no, name);
-        return std::string(name);
-    });
 
 }

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -1,0 +1,7 @@
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(materials, m) {
+    m.doc() = "Materials";
+}

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -25,10 +25,16 @@ PYBIND11_MODULE(materials, m) {
             phase (int): The phase of the material (e.g., condensed or gaseous).
     )pbdoc")
         .def(py::init<long>(), R"pbdoc(
-            Initializes a Material object.
+            Initializes a Material object by ID.
 
             Args:
                 id (int): The unique identifier for the material.
+        )pbdoc")
+        .def(py::init<const std::string &>(), R"pbdoc(
+            Initializes a Material object by name.
+
+            Args:
+                name (str): The name of the material.
         )pbdoc")
         .def_readonly("id", &Material::id, "The unique identifier for the material.")
         .def_readonly("density_g_cm3", &Material::density_g_cm3, "The density of the material in g/cm³.")

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -8,41 +8,58 @@ namespace py = pybind11;
 PYBIND11_MODULE(materials, m) {
     m.doc() = "Functions and data structures for accessing and manipulating material properties.";
 
-    py::class_<Material>(m, "Material")
-        .def(py::init<long>())
-        .def_readonly("id", &Material::id)
-        .def_readonly("density_g_cm3", &Material::density_g_cm3)
-        .def_readonly("I_eV", &Material::I_eV)
-        .def_readonly("alpha_g_cm2_MeV", &Material::alpha_g_cm2_MeV)
-        .def_readonly("p_MeV", &Material::p_MeV)
-        .def_readonly("m_g_cm2", &Material::m_g_cm2)
-        .def_readonly("average_A", &Material::average_A)
-        .def_readonly("average_Z", &Material::average_Z)
-        .def_readonly("name", &Material::name)
-        .def_readonly("phase", &Material::phase);
+    py::class_<Material>(m, "Material", R"pbdoc(
+        Represents a material with various physical properties.
 
-    m.def("get_ids", []() {
-        const AT_table_of_material_data_struct& data = AT_Material_Data;
-        return std::vector<long>(std::begin(data.material_no) + 1, std::begin(data.material_no) + data.n);
-    });
+        Attributes:
+            id (int): The unique identifier for the material.
+            density_g_cm3 (float): The density of the material in g/cm³.
+            I_eV (float): The mean ionization potential in eV.
+            alpha_g_cm2_MeV (float): Fit parameter for power-law representation of stopping power.
+            p_MeV (float): Fit parameter for power-law representation of stopping power.
+            m_g_cm2 (float): Fit parameter for linear representation of fluence changes.
+            average_A (float): The average mass number of the material.
+            average_Z (float): The average atomic number of the material.
+            name (str): The name of the material.
+            phase (int): The phase of the material (e.g., condensed or gaseous).
+    )pbdoc")
+        .def(py::init<long>(), R"pbdoc(
+            Initializes a Material object.
 
-    m.def("get_long_names", []() {
-        const AT_table_of_material_data_struct& data = AT_Material_Data;
-        return std::vector<std::string>(std::begin(data.material_name) + 1, std::begin(data.material_name) + data.n);
-    });
+            Args:
+                id (int): The unique identifier for the material.
+        )pbdoc")
+        .def_readonly("id", &Material::id, "The unique identifier for the material.")
+        .def_readonly("density_g_cm3", &Material::density_g_cm3, "The density of the material in g/cm³.")
+        .def_readonly("I_eV", &Material::I_eV, "The mean ionization potential in eV.")
+        .def_readonly("alpha_g_cm2_MeV", &Material::alpha_g_cm2_MeV, "Fit parameter for power-law representation of stopping power.")
+        .def_readonly("p_MeV", &Material::p_MeV, "Fit parameter for power-law representation of stopping power.")
+        .def_readonly("m_g_cm2", &Material::m_g_cm2, "Fit parameter for linear representation of fluence changes.")
+        .def_readonly("average_A", &Material::average_A, "The average mass number of the material.")
+        .def_readonly("average_Z", &Material::average_Z, "The average atomic number of the material.")
+        .def_readonly("name", &Material::name, "The name of the material.")
+        .def_readonly("phase", &Material::phase, "The phase of the material (e.g., condensed or gaseous).");
 
-    m.def("get_names", []() {
-        const AT_table_of_material_data_struct& data = AT_Material_Data;
-        auto names = std::vector<std::string>(std::begin(data.material_name) + 1, std::begin(data.material_name) + data.n);
-        // replace all spaces with underscores
-        for (auto& name : names) {
-            std::replace(name.begin(), name.end(), ' ', '_');
-        }
-        // remove all non-alphanumeric characters
-        for (auto& name : names) {
-            name.erase(std::remove_if(name.begin(), name.end(), [](char c) { return !std::isalnum(c) && c != '_'; }), name.end());
-        }
-        return names;
-    });
+    m.def("get_ids", &get_ids, R"pbdoc(
+        Retrieves the list of material IDs.
 
+        Returns:
+            list[int]: A list of material IDs.
+    )pbdoc");
+
+    m.def("get_long_names", &get_long_names, R"pbdoc(
+        Retrieves the full names of all materials.
+
+        Returns:
+            list[int]: A list of full material names.
+    )pbdoc");
+
+    m.def("get_names", &get_names, R"pbdoc(
+        Retrieves the sanitized names of all materials.
+
+        The sanitized names replace spaces with underscores and remove non-alphanumeric characters.
+
+        Returns:
+            list[str]: A list of sanitized material names.
+    )pbdoc");
 }

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -21,15 +21,28 @@ PYBIND11_MODULE(materials, m) {
         .def_readonly("name", &Material::name)
         .def_readonly("phase", &Material::phase);
 
-    // Expose get_ids as a proper Python wrapper
     m.def("get_ids", []() {
         const AT_table_of_material_data_struct& data = AT_Material_Data;
-        return std::vector<long>(std::begin(data.material_no), std::begin(data.material_no) + data.n);
+        return std::vector<long>(std::begin(data.material_no) + 1, std::begin(data.material_no) + data.n);
+    });
+
+    m.def("get_long_names", []() {
+        const AT_table_of_material_data_struct& data = AT_Material_Data;
+        return std::vector<std::string>(std::begin(data.material_name) + 1, std::begin(data.material_name) + data.n);
     });
 
     m.def("get_names", []() {
         const AT_table_of_material_data_struct& data = AT_Material_Data;
-        return std::vector<std::string>(std::begin(data.material_name), std::begin(data.material_name) + data.n);
+        auto names = std::vector<std::string>(std::begin(data.material_name) + 1, std::begin(data.material_name) + data.n);
+        // replace all spaces with underscores
+        for (auto& name : names) {
+            std::replace(name.begin(), name.end(), ' ', '_');
+        }
+        // remove all non-alphanumeric characters
+        for (auto& name : names) {
+            name.erase(std::remove_if(name.begin(), name.end(), [](char c) { return !std::isalnum(c) && c != '_'; }), name.end());
+        }
+        return names;
     });
 
 }

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "materials.h"
+#include "AT_DataMaterial.h"
 #include <iostream>
 
 namespace py = pybind11;
@@ -40,7 +41,10 @@ PYBIND11_MODULE(materials, m) {
         .def_readonly("name", &Material::name, "The name of the material.")
         .def_readonly("phase", &Material::phase, "The phase of the material (e.g., condensed or gaseous).");
 
-    m.def("get_ids", &get_ids, R"pbdoc(
+    m.def("get_ids", []() {
+        const AT_table_of_material_data_struct& data = AT_Material_Data;
+        return std::vector<long>(std::begin(data.material_no) + 1, std::begin(data.material_no) + data.n);
+    }, R"pbdoc(
         Retrieves the list of material IDs.
 
         Returns:
@@ -62,4 +66,10 @@ PYBIND11_MODULE(materials, m) {
         Returns:
             list[str]: A list of sanitized material names.
     )pbdoc");
+
+    // Dynamically expose materials as attributes of the module
+    auto names = get_names();
+    for (size_t i = 0; i < names.size(); ++i) {
+        m.attr(names[i].c_str()) = Material(static_cast<long>(i + 1));
+    }
 }

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -1,6 +1,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "materials.h"
+#include <iostream>
 
 namespace py = pybind11;
 
@@ -19,5 +20,16 @@ PYBIND11_MODULE(materials, m) {
         .def_readonly("average_Z", &Material::average_Z)
         .def_readonly("name", &Material::name)
         .def_readonly("phase", &Material::phase);
+
+    // Expose get_ids as a proper Python wrapper
+    m.def("get_ids", []() {
+        const AT_table_of_material_data_struct& data = AT_Material_Data;
+        return std::vector<long>(std::begin(data.material_no), std::begin(data.material_no) + data.n);
+    });
+
+    m.def("get_names", []() {
+        const AT_table_of_material_data_struct& data = AT_Material_Data;
+        return std::vector<std::string>(std::begin(data.material_name), std::begin(data.material_name) + data.n);
+    });
 
 }

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -1,7 +1,23 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include "materials.h"
 
 namespace py = pybind11;
 
 PYBIND11_MODULE(materials, m) {
     m.doc() = "Materials";
+
+    py::class_<Material>(m, "Material")
+        .def(py::init<long>())
+        .def_readonly("material_no", &Material::material_no)
+        .def_readonly("density_g_cm3", &Material::density_g_cm3)
+        .def_readonly("I_eV", &Material::I_eV)
+        .def_readonly("alpha_g_cm2_MeV", &Material::alpha_g_cm2_MeV)
+        .def_readonly("p_MeV", &Material::p_MeV)
+        .def_readonly("m_g_cm2", &Material::m_g_cm2)
+        .def_readonly("average_A", &Material::average_A)
+        .def_readonly("average_Z", &Material::average_Z)
+        .def_readonly("material_name", &Material::material_name)
+        .def_readonly("phase", &Material::phase);
+
 }

--- a/src/materials/materials_bindings.cpp
+++ b/src/materials/materials_bindings.cpp
@@ -61,7 +61,7 @@ PYBIND11_MODULE(materials, m) {
         Retrieves the full names of all materials.
 
         Returns:
-            list[int]: A list of full material names.
+            list[str]: A list of full material names.
     )pbdoc");
 
     m.def("get_names", &get_names, R"pbdoc(

--- a/src/pyamtrack/__init__.py
+++ b/src/pyamtrack/__init__.py
@@ -38,4 +38,4 @@ if sys.platform == "win32":
 from . import converters
 from . import stopping
 
-__all__ = ["converters", "stopping"]
+__all__ = ["converters", "stopping", "materials"]

--- a/src/pyamtrack/__init__.py
+++ b/src/pyamtrack/__init__.py
@@ -37,5 +37,6 @@ if sys.platform == "win32":
 
 from . import converters
 from . import stopping
+from . import materials
 
 __all__ = ["converters", "stopping", "materials"]

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -12,9 +12,18 @@ def test_get_ids():
     assert isinstance(ids, list)
     assert len(ids) > 0
     assert all(isinstance(id, int) for id in ids)
+    assert ids[0] == 1  # Check the first ID
 
-def test_get_names():
+def test_get_long_names():
+    names = pyamtrack.materials.get_long_names()
+    assert isinstance(names, list)
+    assert len(names) > 0
+    assert all(isinstance(name, str) for name in names)
+    assert names[0] == "Water, Liquid"  # Check the first name
+
+def test_get_short_names():
     names = pyamtrack.materials.get_names()
     assert isinstance(names, list)
     assert len(names) > 0
     assert all(isinstance(name, str) for name in names)
+    assert names[0] == "Water_Liquid"  # Check the first name

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,10 +1,25 @@
+import pytest
 import pyamtrack
 
-def test_material_initialization():
+def test_material_initialization_by_id():
     material = pyamtrack.materials.Material(1)  # Water_Liquid
     assert material.id == 1
     assert material.name == "Water, Liquid"
     assert material.density_g_cm3 > 0
+
+def test_material_initialization_by_name():
+    material = pyamtrack.materials.Material("Water, Liquid")
+    assert material.id == 1
+    assert material.name == "Water, Liquid"
+    assert material.density_g_cm3 > 0
+
+def test_material_initialization_by_invalid_id():
+    with pytest.raises(ValueError):
+        pyamtrack.materials.Material(9999)  # Invalid ID
+
+def test_material_initialization_by_invalid_name():
+    with pytest.raises(ValueError):
+        pyamtrack.materials.Material("Invalid Material")  # Invalid name
 
 def test_get_ids():
     ids = pyamtrack.materials.get_ids()

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,8 +1,20 @@
 import pytest
-from pyamtrack.materials import Material
+import pyamtrack
 
 def test_material_initialization():
-    material = Material(1)  # Water_Liquid
+    material = pyamtrack.materials.Material(1)  # Water_Liquid
     assert material.id == 1
     assert material.name == "Water, Liquid"
     assert material.density_g_cm3 > 0
+
+def test_get_ids():
+    ids = pyamtrack.materials.get_ids()
+    assert isinstance(ids, list)
+    assert len(ids) > 0
+    assert all(isinstance(id, int) for id in ids)
+
+def test_get_names():
+    names = pyamtrack.materials.get_names()
+    assert isinstance(names, list)
+    assert len(names) > 0
+    assert all(isinstance(name, str) for name in names)

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -3,6 +3,6 @@ from pyamtrack.materials import Material
 
 def test_material_initialization():
     material = Material(1)  # Water_Liquid
-    assert material.material_no == 1
-    assert material.material_name == "Water, Liquid"
+    assert material.id == 1
+    assert material.name == "Water, Liquid"
     assert material.density_g_cm3 > 0

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,4 +1,3 @@
-import pytest
 import pyamtrack
 
 def test_material_initialization():
@@ -26,4 +25,10 @@ def test_get_short_names():
     assert isinstance(names, list)
     assert len(names) > 0
     assert all(isinstance(name, str) for name in names)
-    assert names[0] == "Water_Liquid"  # Check the first name
+    assert names[0] == "water_liquid"  # Check the first name
+
+def test_via_object():
+    material = pyamtrack.materials.water_liquid
+    assert material.id == 1
+    assert material.name == "Water, Liquid"
+    assert material.density_g_cm3 == 1.0

--- a/tests/test_materials.py
+++ b/tests/test_materials.py
@@ -1,0 +1,8 @@
+import pytest
+from pyamtrack.materials import Material
+
+def test_material_initialization():
+    material = Material(1)  # Water_Liquid
+    assert material.material_no == 1
+    assert material.material_name == "Water, Liquid"
+    assert material.density_g_cm3 > 0

--- a/tests/test_stopping.py
+++ b/tests/test_stopping.py
@@ -1,6 +1,4 @@
-import pytest
 import pyamtrack.stopping
-import numpy as np
 
 
 def test_electron_range():


### PR DESCRIPTION
This pull request introduces a new `materials` module to the project, which includes the implementation of a `Material` class and related functions for accessing and manipulating material properties. Additionally, it updates the build configuration and adds corresponding tests for the new functionality.

### New `materials` module:

* [`src/materials/materials.cpp`](diffhunk://#diff-2be79031e5213d293e67e90a955755b4087a2bd61c1c530d69a22c1cd4c9a28aR1-R56): Implemented the `Material` class with constructors for initialization by ID and name, and added functions to retrieve material IDs, long names, and sanitized names.
* [`src/materials/materials.h`](diffhunk://#diff-e4f361b139fa57107b519b56780b2b0f78af3214a5cce0d2ab32b1eb405dfefeR1-R116): Declared the `Material` class and functions for retrieving material properties.
* [`src/materials/materials_bindings.cpp`](diffhunk://#diff-339c4e623c118f33da9472206f66739b0e7b079a3b47547942ca7477479da7c8R1-R81): Created Python bindings for the `Material` class and functions using `pybind11`.

### Build configuration updates:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL112-R112): Updated the `PYAMTRACK_TARGETS` to include the new `materials` target.

### Test additions:

* [`tests/test_materials.py`](diffhunk://#diff-269c51726a1d8765ce688c3bc6412aabee83b3487c3bc4ffd4f903364de56d8dR1-R49): Added tests for the `Material` class and functions, including initialization by ID and name, and retrieval of material IDs and names.

### Other changes:

* [`src/pyamtrack/__init__.py`](diffhunk://#diff-871b554e452e6e38ae9213f6a611e6ffea5ec2a1e95af57baab505f1d0989733R40-R42): Updated the module imports to include the new `materials` module.
* [`tests/test_stopping.py`](diffhunk://#diff-62bab7bb1fed0e3677a2009d0014309e7155c57745505225425ab7d34509292cL1-L3): Removed an unused import statement.