### PR TITLE
Enhance electron_range function to accept material parameter 

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -28,6 +28,7 @@ python -m build --wheel --no-isolation --config-setting=build-dir=./build || err
 
 # Install the built wheel
 echo "Installing the built wheel..."
+pip uninstall pyamtrack -y || error "Failed to uninstall existing pyamtrack package."
 pip install dist/*.whl || error "Failed to install the package from the dist directory."
 
 # Test with pip show to verify installation

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -1,6 +1,5 @@
 #include "../wrapper_template.h"
 #include "electron_range.h"
-#include <iostream>
 
 extern "C" {
     #include "AT_ElectronRange.h"

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -16,13 +16,13 @@ py::object electron_range(py::object input, py::object material) {
         py::object Material = materials.attr("Material");
 
         if (!py::isinstance(material, Material)) {
-            throw py::type_error("Material argument must be either an integer or a Material object with an 'id' attribute");
+            throw py::type_error("Material argument must be either an integer or a Material object");
         }
         
         try {
             material_id = material.attr("id").cast<int>();
         } catch (const py::error_already_set&) {
-            throw py::type_error("Material argument must be either an integer or a Material object with an 'id' attribute");
+            throw py::type_error("Material argument must be either an integer or a Material object");
         }
     }
 

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -22,7 +22,7 @@ py::object electron_range(py::object input, py::object material) {
         try {
             material_id = material.attr("id").cast<int>();
         } catch (const py::error_already_set&) {
-            throw py::type_error("Material object must have 'id' attribute");
+            throw py::type_error("Material argument must be either an integer or a Material object with an 'id' attribute");
         }
     }
 

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -17,11 +17,19 @@ py::object electron_range(py::object input, py::object material = py::int_(1)) {
     if (py::isinstance<py::int_>(material)) {
         material_id = material.cast<int>();
     } else {
-        // Assuming Material class has a get_id() method
+        // Check if material is an instance of Material class
+        py::module_ builtins = py::module_::import("builtins");
+        py::object type_func = builtins.attr("type");
+        py::str type_name = type_func(material).attr("__name__").cast<py::str>();
+        
+        if (std::string(type_name) != "Material") {
+            throw py::type_error("Material argument must be either an integer or a Material object");
+        }
+        
         try {
             material_id = material.attr("id").cast<int>();
         } catch (const py::error_already_set&) {
-            throw py::type_error("Material argument must be either an integer or a Material object with 'id' attribute");
+            throw py::type_error("Material object must have 'id' attribute");
         }
     }
     return wrap_function(electron_range_single, input);

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -1,5 +1,6 @@
 #include "../wrapper_template.h"
 #include "electron_range.h"
+#include <iostream>
 
 extern "C" {
     #include "AT_ElectronRange.h"
@@ -11,6 +12,17 @@ double electron_range_single(double E_MeV_u) {
 }
 
 // Main function to handle different input types
-py::object electron_range(py::object input) {
+py::object electron_range(py::object input, py::object material = py::int_(1)) {
+    int material_id = 0;
+    if (py::isinstance<py::int_>(material)) {
+        material_id = material.cast<int>();
+    } else {
+        // Assuming Material class has a get_id() method
+        try {
+            material_id = material.attr("id").cast<int>();
+        } catch (const py::error_already_set&) {
+            throw py::type_error("Material argument must be either an integer or a Material object with 'id' attribute");
+        }
+    }
     return wrap_function(electron_range_single, input);
 }

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -16,7 +16,7 @@ py::object electron_range(py::object input, py::object material) {
         py::object Material = materials.attr("Material");
 
         if (!py::isinstance(material, Material)) {
-            throw py::type_error("Material argument must be either an integer or a Material object");
+            throw py::type_error("Material argument must be either an integer or a Material object with an 'id' attribute");
         }
         
         try {

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -6,7 +6,7 @@ extern "C" {
 }
 
 // Main function to handle different input types
-py::object electron_range(py::object input, py::object material = py::int_(1)) {
+py::object electron_range(py::object input, py::object material) {
     int material_id = 0;
     if (py::isinstance<py::int_>(material)) {
         material_id = material.cast<int>();

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -6,11 +6,6 @@ extern "C" {
     #include "AT_ElectronRange.h"
 }
 
-// Helper function for single value calculation
-double electron_range_single(double E_MeV_u) {
-    return AT_max_electron_range_m(E_MeV_u, 1, 7);
-}
-
 // Main function to handle different input types
 py::object electron_range(py::object input, py::object material = py::int_(1)) {
     int material_id = 0;
@@ -32,5 +27,11 @@ py::object electron_range(py::object input, py::object material = py::int_(1)) {
             throw py::type_error("Material object must have 'id' attribute");
         }
     }
+
+    // create a lambda function to capture material_id
+    auto electron_range_single = [material_id](double E_MeV_u) {
+        return AT_max_electron_range_m(E_MeV_u, material_id, 7);
+    };
+
     return wrap_function(electron_range_single, input);
 }

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -16,7 +16,7 @@ py::object electron_range(py::object input, py::object material = py::int_(1)) {
         py::object Material = materials.attr("Material");
 
         if (!py::isinstance(material, Material)) {
-            throw py::type_error("Material argument must be either an integer or a Material object DUPA");
+            throw py::type_error("Material argument must be either an integer or a Material object");
         }
         
         try {

--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -11,13 +11,12 @@ py::object electron_range(py::object input, py::object material = py::int_(1)) {
     if (py::isinstance<py::int_>(material)) {
         material_id = material.cast<int>();
     } else {
-        // Check if material is an instance of Material class
-        py::module_ builtins = py::module_::import("builtins");
-        py::object type_func = builtins.attr("type");
-        py::str type_name = type_func(material).attr("__name__").cast<py::str>();
-        
-        if (std::string(type_name) != "Material") {
-            throw py::type_error("Material argument must be either an integer or a Material object");
+        py::module_ pyamtrack = py::module_::import("pyamtrack");
+        py::module_ materials = pyamtrack.attr("materials");
+        py::object Material = materials.attr("Material");
+
+        if (!py::isinstance(material, Material)) {
+            throw py::type_error("Material argument must be either an integer or a Material object DUPA");
         }
         
         try {

--- a/src/stopping/electron_range.h
+++ b/src/stopping/electron_range.h
@@ -5,6 +5,6 @@
 
 namespace py = pybind11;
 
-py::object PYBIND11_EXPORT electron_range(py::object input);
+py::object PYBIND11_EXPORT electron_range(py::object input, py::object material);
 
 #endif // ELECTRON_RANGE_H

--- a/src/stopping/electron_range.h
+++ b/src/stopping/electron_range.h
@@ -5,6 +5,6 @@
 
 namespace py = pybind11;
 
-py::object PYBIND11_EXPORT electron_range(py::object input, py::object material);
+py::object PYBIND11_EXPORT electron_range(py::object input, py::object material = py::int_(1));
 
 #endif // ELECTRON_RANGE_H

--- a/src/stopping/stopping_bindings.cpp
+++ b/src/stopping/stopping_bindings.cpp
@@ -16,7 +16,7 @@ PYBIND11_MODULE(stopping, m) {
             Calculate electron range (m).
     
             Parameters:
-                input (float | int | numpy.ndarray | list): The energy per nucleon in MeV. Can be a single value, a NumPy array, or a Python list.
+                input (float | int | numpy.ndarray | list): The energy in MeV. Can be a single value, a NumPy array, or a Python list.
                 material (int | Material, optional): Either a material ID as integer or a Material object. Defaults to 1 (Liquid water).
     
             Returns:

--- a/src/stopping/stopping_bindings.cpp
+++ b/src/stopping/stopping_bindings.cpp
@@ -10,15 +10,17 @@ PYBIND11_MODULE(stopping, m) {
         "electron_range",
         &electron_range,
         py::arg("input"),
+        py::arg("material") = 1,
         py::return_value_policy::automatic,
         R"pbdoc(
-        Calculate electron range (m).
-
-        Parameters:
-            input (float | int | numpy.ndarray | list): The energy per nucleon in MeV. Can be a single value, a NumPy array, or a Python list.
-
-        Returns:
-            float | numpy.ndarray | list: The calculated electron range(s). Returns a float for a single input, a NumPy array for a NumPy array input, or a Python list for a list input.
-        )pbdoc"
+            Calculate electron range (m).
+    
+            Parameters:
+                input (float | int | numpy.ndarray | list): The energy per nucleon in MeV. Can be a single value, a NumPy array, or a Python list.
+                material (int | Material, optional): Either a material ID as integer or a Material object. Defaults to 1.
+    
+            Returns:
+                float | numpy.ndarray | list: The calculated electron range(s). Returns a float for a single input, a NumPy array for a NumPy array input, or a Python list for a list input.
+            )pbdoc"
     );
 }

--- a/src/stopping/stopping_bindings.cpp
+++ b/src/stopping/stopping_bindings.cpp
@@ -17,7 +17,7 @@ PYBIND11_MODULE(stopping, m) {
     
             Parameters:
                 input (float | int | numpy.ndarray | list): The energy per nucleon in MeV. Can be a single value, a NumPy array, or a Python list.
-                material (int | Material, optional): Either a material ID as integer or a Material object. Defaults to 1.
+                material (int | Material, optional): Either a material ID as integer or a Material object. Defaults to 1 (Liquid water).
     
             Returns:
                 float | numpy.ndarray | list: The calculated electron range(s). Returns a float for a single input, a NumPy array for a NumPy array input, or a Python list for a list input.

--- a/tests/test_stopping.py
+++ b/tests/test_stopping.py
@@ -29,3 +29,9 @@ def test_material_assignment_invalid():
         pyamtrack.stopping.electron_range(1000.0, "aaa")  # Invalid ID
     with pytest.raises(TypeError, match="Material argument must be either an integer or a Material object"):
         pyamtrack.stopping.electron_range(1000.0, pyamtrack.materials.get_ids)
+
+@pytest.mark.skip
+def test_invalid_id():
+    """Test the electron_range function with an invalid ID."""
+    with pytest.raises(ValueError, match="Invalid material ID"):
+        pyamtrack.stopping.electron_range(1000.0, 1000000)

--- a/tests/test_stopping.py
+++ b/tests/test_stopping.py
@@ -1,3 +1,4 @@
+import pytest
 import pyamtrack.stopping
 
 
@@ -6,3 +7,25 @@ def test_electron_range():
     energy = 1000.0  # MeV
     range_m = pyamtrack.stopping.electron_range(energy)
     assert range_m > 0.01, "Expected positive range for positive energy."
+
+def test_electron_range_air_vs_water():
+    """Test the electron_range function for air and water."""
+    energy = 1000.0  # MeV
+    range_air = pyamtrack.stopping.electron_range(energy, pyamtrack.materials.air)
+    range_water = pyamtrack.stopping.electron_range(energy, pyamtrack.materials.water_liquid)
+    assert range_air > range_water, "Expected range in air to be larger than in water."
+
+def test_material_assignment():
+    """Test the material assignment by ID."""
+    range_default = pyamtrack.stopping.electron_range(1000.0)
+    range_material_name = pyamtrack.stopping.electron_range(1000.0, pyamtrack.materials.water_liquid)
+    assert range_default == range_material_name, "Expected range to be the same for default and material name."
+    range_material_id = pyamtrack.stopping.electron_range(1000.0, 1)
+    assert range_default == range_material_id, "Expected range to be the same for default and material ID."
+
+def test_material_assignment_invalid():
+    """Test the material assignment with an invalid ID."""
+    with pytest.raises(TypeError, match="Material argument must be either an integer or a Material object"):
+        pyamtrack.stopping.electron_range(1000.0, "aaa")  # Invalid ID
+    with pytest.raises(TypeError, match="Material argument must be either an integer or a Material object"):
+        pyamtrack.stopping.electron_range(1000.0, pyamtrack.materials.get_ids)

--- a/tests/test_stopping.py
+++ b/tests/test_stopping.py
@@ -3,43 +3,43 @@ import pyamtrack.stopping
 
 
 @pytest.fixture
-def test_energy():
+def electron_energy_MeV():
     """Fixture providing the electron energy in MeV for tests."""
     return 1000.0
 
 
-def test_electron_range(test_energy):
+def test_electron_range(electron_energy_MeV):
     """Test the electron_range function for various inputs."""
-    range_m = pyamtrack.stopping.electron_range(test_energy)
+    range_m = pyamtrack.stopping.electron_range(electron_energy_MeV)
     assert range_m > 0.01, "Expected positive range for positive energy."
 
  
-def test_electron_range_air_vs_water(test_energy):
+def test_electron_range_air_vs_water(electron_energy_MeV):
     """Test the electron_range function for air and water."""
-    range_air = pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.air)
-    range_water = pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.water_liquid)
+    range_air = pyamtrack.stopping.electron_range(electron_energy_MeV, pyamtrack.materials.air)
+    range_water = pyamtrack.stopping.electron_range(electron_energy_MeV, pyamtrack.materials.water_liquid)
     assert range_air > range_water, "Expected range in air to be larger than in water."
 
 
-def test_material_assignment(test_energy):
+def test_material_assignment(electron_energy_MeV):
     """Test the material assignment by ID."""
-    range_default = pyamtrack.stopping.electron_range(test_energy)
-    range_material_name = pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.water_liquid)
+    range_default = pyamtrack.stopping.electron_range(electron_energy_MeV)
+    range_material_name = pyamtrack.stopping.electron_range(electron_energy_MeV, pyamtrack.materials.water_liquid)
     assert range_default == range_material_name, "Expected range to be the same for default and material name."
-    range_material_id = pyamtrack.stopping.electron_range(test_energy, 1)
+    range_material_id = pyamtrack.stopping.electron_range(electron_energy_MeV, 1)
     assert range_default == range_material_id, "Expected range to be the same for default and material ID."
 
 
-def test_material_assignment_invalid(test_energy):
+def test_material_assignment_invalid(electron_energy_MeV):
     """Test the material assignment with an invalid ID."""
     with pytest.raises(TypeError, match="Material argument must be either an integer or a Material object"):
-        pyamtrack.stopping.electron_range(test_energy, "aaa")  # Invalid ID
+        pyamtrack.stopping.electron_range(electron_energy_MeV, "aaa")  # Invalid ID
     with pytest.raises(TypeError, match="Material argument must be either an integer or a Material object"):
-        pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.get_ids)
+        pyamtrack.stopping.electron_range(electron_energy_MeV, pyamtrack.materials.get_ids)
 
 
 @pytest.mark.skip
-def test_invalid_id(test_energy):
+def test_invalid_id(electron_energy_MeV):
     """Test the electron_range function with an invalid ID."""
     with pytest.raises(ValueError, match="Invalid material ID"):
-        pyamtrack.stopping.electron_range(test_energy, 1000000)
+        pyamtrack.stopping.electron_range(electron_energy_MeV, 1000000)

--- a/tests/test_stopping.py
+++ b/tests/test_stopping.py
@@ -2,36 +2,44 @@ import pytest
 import pyamtrack.stopping
 
 
-def test_electron_range():
+@pytest.fixture
+def test_energy():
+    """Fixture providing the electron energy in MeV for tests."""
+    return 1000.0
+
+
+def test_electron_range(test_energy):
     """Test the electron_range function for various inputs."""
-    energy = 1000.0  # MeV
-    range_m = pyamtrack.stopping.electron_range(energy)
+    range_m = pyamtrack.stopping.electron_range(test_energy)
     assert range_m > 0.01, "Expected positive range for positive energy."
 
-def test_electron_range_air_vs_water():
+ 
+def test_electron_range_air_vs_water(test_energy):
     """Test the electron_range function for air and water."""
-    energy = 1000.0  # MeV
-    range_air = pyamtrack.stopping.electron_range(energy, pyamtrack.materials.air)
-    range_water = pyamtrack.stopping.electron_range(energy, pyamtrack.materials.water_liquid)
+    range_air = pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.air)
+    range_water = pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.water_liquid)
     assert range_air > range_water, "Expected range in air to be larger than in water."
 
-def test_material_assignment():
+
+def test_material_assignment(test_energy):
     """Test the material assignment by ID."""
-    range_default = pyamtrack.stopping.electron_range(1000.0)
-    range_material_name = pyamtrack.stopping.electron_range(1000.0, pyamtrack.materials.water_liquid)
+    range_default = pyamtrack.stopping.electron_range(test_energy)
+    range_material_name = pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.water_liquid)
     assert range_default == range_material_name, "Expected range to be the same for default and material name."
-    range_material_id = pyamtrack.stopping.electron_range(1000.0, 1)
+    range_material_id = pyamtrack.stopping.electron_range(test_energy, 1)
     assert range_default == range_material_id, "Expected range to be the same for default and material ID."
 
-def test_material_assignment_invalid():
+
+def test_material_assignment_invalid(test_energy):
     """Test the material assignment with an invalid ID."""
     with pytest.raises(TypeError, match="Material argument must be either an integer or a Material object"):
-        pyamtrack.stopping.electron_range(1000.0, "aaa")  # Invalid ID
+        pyamtrack.stopping.electron_range(test_energy, "aaa")  # Invalid ID
     with pytest.raises(TypeError, match="Material argument must be either an integer or a Material object"):
-        pyamtrack.stopping.electron_range(1000.0, pyamtrack.materials.get_ids)
+        pyamtrack.stopping.electron_range(test_energy, pyamtrack.materials.get_ids)
+
 
 @pytest.mark.skip
-def test_invalid_id():
+def test_invalid_id(test_energy):
     """Test the electron_range function with an invalid ID."""
     with pytest.raises(ValueError, match="Invalid material ID"):
-        pyamtrack.stopping.electron_range(1000.0, 1000000)
+        pyamtrack.stopping.electron_range(test_energy, 1000000)


### PR DESCRIPTION
This pull request includes several significant changes to the `electron_range` function and related files to enhance its functionality and testing. The changes include adding support for material objects, updating the function signature, and expanding the test coverage.

Enhancements to `electron_range` function:

* [`src/stopping/electron_range.cpp`](diffhunk://#diff-a61ac4496e9a22ff3c660b80443d3425ecad6b983ef5f77ae950fdf5bbe002daL8-R33): Modified the `electron_range` function to accept an additional `material` parameter, which can be either an integer or a `Material` object. Added error handling for invalid material types and attributes.
* [`src/stopping/electron_range.h`](diffhunk://#diff-6412be15b3cde7648f0f5764aaced441e619892663e5c58991ef7c8a9a151c3dL8-R8): Updated the function declaration to include the new `material` parameter.
* [`src/stopping/stopping_bindings.cpp`](diffhunk://#diff-67625a1f5828c48ebe43dac901fc937a93b9839c96101ae4d25fad8ca42c1eddR13-R20): Updated the Pybind11 module definition to include the new `material` parameter with a default value of 1.

Testing improvements:

* [`tests/test_stopping.py`](diffhunk://#diff-62bab7bb1fed0e3677a2009d0014309e7155c57745505225425ab7d34509292cR1-R45): Added new tests to verify the functionality of the `electron_range` function with different materials, including valid and invalid material IDs and objects. Introduced the use of `pytest` fixtures for test setup.

Build script update:

* [`scripts/build_linux.sh`](diffhunk://#diff-bf2a9d7ae77d5e292b9e591d6d7e4866467f0db615e925458720cea0d2b1abf8R31): Added a command to uninstall the existing `pyamtrack` package before installing the newly built wheel to ensure a clean installation.