### PR TITLE
Remove pull request trigger and paths-ignore from CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,13 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.yaml'
-      - '**/*.json'
-      - '**/*.toml'
   schedule:
     - cron: '26 15 * * 2'
 


### PR DESCRIPTION
This pull request updates the `codeql.yml` workflow configuration to simplify its triggers by removing unnecessary pull request-related settings.

Workflow configuration changes:

* [`.github/workflows/codeql.yml`](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L7-L13): Removed the `pull_request` trigger, including its branch specification and `paths-ignore` settings, to streamline the workflow and focus on `push` and `schedule` triggers.