### PR TITLE
use std::variant for double/int functions

### DIFF
--- a/src/stopping/electron_range.cpp
+++ b/src/stopping/electron_range.cpp
@@ -65,13 +65,17 @@ nb::object get_id(const nb::object& object, const ids_getter& getter) {
 nb::object electron_range(const nb::object& input, const nb::object& material, const nb::object& model) {
   std::vector<nb::object> arguments_vector;
   arguments_vector.push_back(input);
-  auto electron_range_vector = [](std::vector<double> vec) -> double {
+  arguments_vector.push_back(get_id(material, process_material));  // unifying materials to int
+  arguments_vector.push_back(get_id(model, process_model));        // unifying models to int
+  auto electron_range_vector = [](const std::vector<std::variant<double, int>>& vec) -> double {
     if (vec.size() < 3) {
       throw std::invalid_argument("Input vector must have at least three elements.");
     }
-    return AT_max_electron_range_m(vec[0], (int)vec[1], (int)vec[2]);
+    double energy = variant_cast<double>(vec[0]);
+    int mat_id = variant_cast<int>(vec[1]);
+    int model_id = variant_cast<int>(vec[2]);
+
+    return AT_max_electron_range_m(energy, mat_id, model_id);
   };
-  arguments_vector.push_back(get_id(material, process_material));  // unifying materials to int
-  arguments_vector.push_back(get_id(model, process_model));        // unifying models to int
   return wrap_multiargument_function(electron_range_vector, arguments_vector);
 }


### PR DESCRIPTION
This pull request introduces changes to enhance type handling in multi-argument functions by replacing `double` with `std::variant<double, int>` in several parts of the codebase. This allows the functions to handle mixed types (both `double` and `int`) more effectively. Key changes include updating type definitions, modifying function implementations to support the new type, and introducing a utility function for safe type conversion.

### Type Handling Enhancements:

* [`src/wrapper_template.h`](diffhunk://#diff-8d6bf9dc51854b42625301d91ce8b3a608e69a364cb59097d4a798458ac86987R13-R20): Updated the `MultiargumentFunc` type definition to accept a `std::vector<std::variant<double, int>>` instead of `std::vector<double>`. This enables the handling of arguments with mixed types.

* [`src/wrapper_template.h`](diffhunk://#diff-8d6bf9dc51854b42625301d91ce8b3a608e69a364cb59097d4a798458ac86987L117-R125): Modified the `wrap_multiargument_function` implementation to cast arguments to either `double` or `int` based on their type, using `PyFloat_Check` for type checking. [[1]](diffhunk://#diff-8d6bf9dc51854b42625301d91ce8b3a608e69a364cb59097d4a798458ac86987L117-R125) [[2]](diffhunk://#diff-8d6bf9dc51854b42625301d91ce8b3a608e69a364cb59097d4a798458ac86987L154-R169)

* [`src/wrapper_template.h`](diffhunk://#diff-8d6bf9dc51854b42625301d91ce8b3a608e69a364cb59097d4a798458ac86987R194-R201): Added a `variant_cast` utility template function to safely extract and convert values from `std::variant<double, int>` to a specified type using `std::visit`.

### Functionality Updates in `electron_range`:

* [`src/stopping/electron_range.cpp`](diffhunk://#diff-a61ac4496e9a22ff3c660b80443d3425ecad6b983ef5f77ae950fdf5bbe002daL68-L75): Updated the `electron_range` function to use `std::variant<double, int>` for its argument vector. This includes changes to the lambda function to handle the new type and retrieve `double` and `int` values using `variant_cast`.