### PR TITLE
Add architecture and pre-release options to Python setup

### DIFF
--- a/.github/workflows/linux-reusable.yml
+++ b/.github/workflows/linux-reusable.yml
@@ -25,6 +25,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
+          architecture: "x64"  # Ensure we use the x64 architecture
+          allow-prerelease: true  # Allow pre-release versions if needed
 
       - name: Install Python build tools
         run: pip install --upgrade build

--- a/.github/workflows/linux-reusable.yml
+++ b/.github/workflows/linux-reusable.yml
@@ -25,8 +25,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          architecture: "x64"  # Ensure we use the x64 architecture
-          allow-prerelease: true  # Allow pre-release versions if needed
 
       - name: Install Python build tools
         run: pip install --upgrade build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -71,7 +71,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: '>=3.9 <3.13.3 || >=3.13.5' # fix for https://github.com/spacetelescope/drizzle/pull/186
 
       - name: Install Python dependencies
         run: pip install --upgrade build


### PR DESCRIPTION
This pull request updates the Python version specification in the `.github/workflows/windows.yml` file to address compatibility issues with the `drizzle` library.

* [`.github/workflows/windows.yml`](diffhunk://#diff-5ce5c9ff86f58b1f87b35b5227b2e84cb69f022d6741e1854f3e1e181091773cL74-R74): Updated the `python-version` in the `setup-python` action to `'>=3.9 <3.13.3 || >=3.13.5'` to resolve compatibility issues as described in the `drizzle` library's pull request #186.