### PR TITLE
Fix CI config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ include = ["pyamtrack", "pyamtrack.*"]
 
 [tool.cibuildwheel]
 archs = ["auto64"]
-build = ["cp39-* cp310-* cp311-* cp312-* cp313-*"]
+build = ["cp39-*", "cp310-*", "cp311-*", "cp312-*", "cp313-*"]
 skip = "cp3??t-*"
 test-requires = "pytest"
 test-command = "pytest {project}/tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ include = ["pyamtrack", "pyamtrack.*"]
 
 [tool.cibuildwheel]
 archs = ["auto64"]
-skip= ["cp36-*", "cp37-*", "cp38-*", "pp*"]
+build = ["cp39-* cp310-* cp311-* cp312-* cp313-*"]
+skip = "cp3??t-*"
 test-requires = "pytest"
 test-command = "pytest {project}/tests"
 


### PR DESCRIPTION
This pull request updates the build configuration for the project in `pyproject.toml`, specifically refining which Python versions and architectures are targeted during the build process.

Build configuration updates:

* Changed the `cibuildwheel` configuration to explicitly build for Python versions 3.9 through 3.13 (`cp39-*`, `cp310-*`, `cp311-*`, `cp312-*`, `cp313-*`) instead of skipping certain versions.
* Updated the `skip` field to exclude all Python 3 "t" tagged interpreters (e.g., `cp3??t-*`) instead of listing each version to skip.